### PR TITLE
Főoldalon, láblécben lévő linkek javítása

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -131,7 +131,7 @@ const config = {
             items: [
               {
                 label: 'Tutorial',
-                to: '/docs/intro',
+                to: '/docs/tutorials/intro',
               },
             ],
           },

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -19,7 +19,7 @@ function HomepageHeader() {
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
-            to="/docs/intro">
+            to="/docs/tutorials/intro">
             Docusaurus Tutorial - 5min ⏱️
           </Link>
         </div>


### PR DESCRIPTION
A docusaurus.config.js -ben az onBrokenLinks: 'throw', maradt nálam, így
-a docusaurus.config.js-ben a 135.sor törött linket okozott, így lett ok:  to: '/docs/tutorials/intro',
-az src/pages/index.js -ben a 22. sor törött linket okozott, nálam így lett ok: to="/docs/tutorials/intro">

A discordos egyeztetés alapján javíottam.